### PR TITLE
Properly generate slugs for strings that contain `e` characters with …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.2.1
+=====
+
+*   (bug) Properly generate slugs for strings that contain `e` characters with accents.
+
+
 1.2.0
 =====
 

--- a/src/Generator/SlugGenerator.php
+++ b/src/Generator/SlugGenerator.php
@@ -32,6 +32,7 @@ class SlugGenerator
             '/ü/u' => "ue",
             '/[úûù]/u' => "u",
             '/ß/u' => "ss",
+            '/[éêè]/u' => "e",
         ];
         $this->patterns = \array_keys($transforms);
         $this->replacements = \array_values($transforms);


### PR DESCRIPTION
…accents

| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    |no                                                                |
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  |no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? |no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

Properly generate slugs for strings that contain `e` characters with accents.
